### PR TITLE
fix: ensure claude uses real Claude CLI, not local agent

### DIFF
--- a/docs/SESSION_COMMANDS.md
+++ b/docs/SESSION_COMMANDS.md
@@ -1,5 +1,15 @@
 # Session Commands: Codex, Claude, Cursor vs Local Agent
 
+## Default: `claude` = Real Claude CLI
+
+**By default, `claude` should start the real Claude CLI (Anthropic's app), not the local agent.**
+
+- `claude` → real Claude Code CLI (Anthropic)
+- `codex` → real Codex CLI
+- `cursor` → Cursor IDE
+
+Use `./local-claude`, `./local-codex`, or `./Local` **only when you explicitly want** the local Ollama agent.
+
 ## Opening Codex, Claude, or Cursor
 
 Codex, Claude, and Cursor run independently of the local agent. When you type `claude`, `codex`, or `cursor` in chat, the AI should help you open that app, not the local agent.
@@ -20,7 +30,11 @@ bash scripts/fix_shell_claude_codex.sh --fix
 Then either **open a new terminal** or in the same shell run:
 
 ```bash
+# Option A: One-liner (clears cached functions, then reloads .zshrc)
 unset -f codex claude 2>/dev/null; source ~/.zshrc
+
+# Option B: Helper script (must be sourced, not just run)
+source scripts/use_real_claude.sh
 ```
 
 `source ~/.zshrc` alone does *not* remove already-defined functions—they persist until you `unset -f` them or start a fresh shell. After that, `claude` and `codex` resolve to the real apps (or "command not found" if not installed).

--- a/scripts/claude_cli_reinstall.sh
+++ b/scripts/claude_cli_reinstall.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Uninstall and reinstall Claude CLI for a clean independent session.
+# Uses official Anthropic method: https://docs.anthropic.com/en/docs/claude-code/setup
+
+set -euo pipefail
+
+echo "=== Claude CLI: Uninstall + Reinstall ==="
+echo ""
+
+# 1. Remove local-agent-runtime overrides so they don't shadow the fresh install
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+RC_FILE="${ZDOTDIR:-$HOME}/.zshrc"
+if [ -f "$RC_FILE" ] && grep -qE "start_(codex|claude)_compatible" "$RC_FILE" 2>/dev/null; then
+  echo "Disabling local-agent overrides in .zshrc..."
+  bash "$REPO_ROOT/scripts/fix_shell_claude_codex.sh" --fix
+fi
+
+# 2. Uninstall: remove Claude Code binary and versions (per Anthropic docs)
+echo "Removing Claude Code installation..."
+rm -f ~/.local/bin/claude
+rm -f ~/.local/bin/claude.local-agent-wrapper.bak
+rm -f ~/.local/bin/claude.local-agent.bak
+rm -rf ~/.local/share/claude
+
+echo "Uninstall complete."
+echo ""
+
+# 3. Reinstall via official installer
+echo "Reinstalling Claude CLI (official method)..."
+curl -fsSL https://claude.ai/install.sh | bash
+
+echo ""
+echo "=== Done ==="
+echo "Run: source ~/.zshrc  # or open a new terminal"
+echo "Then: claude          # starts independent Claude CLI session"
+echo ""
+echo "To restore local-agent overrides (claude -> local Ollama):"
+echo "  bash scripts/restore_local_agent_claude_codex.sh"

--- a/scripts/fix_shell_claude_codex.sh
+++ b/scripts/fix_shell_claude_codex.sh
@@ -11,11 +11,19 @@ RC_FILE="${ZDOTDIR:-$HOME}/.zshrc"
 echo "=== Diagnosing claude/codex commands ==="
 echo ""
 echo "Current 'claude' resolves to:"
-(type claude 2>/dev/null || echo "  (not found)")
+CLAUDE_TYPE=$(type claude 2>/dev/null || echo "  (not found)")
+echo "$CLAUDE_TYPE"
 echo ""
 echo "Current 'codex' resolves to:"
-(type codex 2>/dev/null || echo "  (not found)")
+CODEX_TYPE=$(type codex 2>/dev/null || echo "  (not found)")
+echo "$CODEX_TYPE"
 echo ""
+if echo "$CLAUDE_TYPE $CODEX_TYPE" | grep -q "shell function"; then
+  echo "*** claude/codex are SHELL FUNCTIONS - they override the real CLI. ***"
+  echo "*** Run this to fix (or open a NEW terminal):                       ***"
+  echo "***   unset -f codex claude 2>/dev/null; source ~/.zshrc            ***"
+  echo ""
+fi
 echo "Checking $RC_FILE and ~/.local/bin for overrides..."
 echo ""
 
@@ -24,9 +32,18 @@ if [ -f "$RC_FILE" ]; then
 fi
 for cmd in claude codex; do
   p="$HOME/.local/bin/$cmd"
-  if [ -f "$p" ]; then
-    echo "  $p contents:"
-    head -3 "$p" | sed 's/^/    /'
+  if [ -f "$p" ] || [ -L "$p" ]; then
+    echo "  $p:"
+    if [ -L "$p" ]; then
+      echo "    -> $(readlink "$p")"
+    elif [ -f "$p" ]; then
+      sz=$(stat -f%z "$p" 2>/dev/null || stat -c%s "$p" 2>/dev/null || echo 0)
+      if [ "${sz:-0}" -lt 500 ] 2>/dev/null; then
+        head -3 "$p" 2>/dev/null | sed 's/^/    /' || echo "    (binary or unreadable)"
+      else
+        echo "    (binary, ${sz} bytes)"
+      fi
+    fi
   fi
 done
 
@@ -105,11 +122,26 @@ done
 
 if [ "$APPLIED" -eq 1 ]; then
   echo ""
-  echo "Done. Run one of:"
-  echo "  1. Open a NEW terminal (recommended - clears old function definitions)"
-  echo "  2. Run: unset -f codex claude 2>/dev/null; source $RC_FILE"
-  echo "Then: claude -> real Claude, codex -> real Codex"
-  echo "Use local-claude or local-codex when you want the local agent."
-else
+  echo "Done."
+  echo ""
+  echo "IMPORTANT: If claude/codex still opens local agent, the shell function is cached."
+  echo "  Run BOTH commands (in order):"
+  echo "    unset -f codex claude 2>/dev/null"
+  echo "    source ~/.zshrc"
+  echo "  OR open a brand NEW terminal tab/window."
+  echo ""
+  echo "Then: claude -> real Claude CLI, codex -> real Codex"
+  echo "Use ./local-claude or ./local-codex when you want the local Ollama agent."
+fi
+
+# If no changes but claude is a function, warn
+if [ "$APPLIED" -eq 0 ] && type claude 2>/dev/null | grep -q "shell function"; then
+  echo ""
+  echo "claude is a shell function (shadows real CLI). To use real Claude:"
+  echo "  unset -f claude codex 2>/dev/null; source ~/.zshrc"
+  echo "  OR open a new terminal."
+fi
+
+if [ "$APPLIED" -eq 0 ] && ! type claude 2>/dev/null | grep -q "shell function"; then
   echo "  No local-agent overrides found."
 fi

--- a/scripts/use_real_claude.sh
+++ b/scripts/use_real_claude.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Run this in your CURRENT terminal to clear cached claude/codex functions
+# so 'claude' uses the real Claude CLI instead of the local agent.
+#
+# Usage: source scripts/use_real_claude.sh
+# (source = runs in current shell so unset takes effect)
+
+unset -f codex claude 2>/dev/null
+[ -f ~/.zshrc ] && source ~/.zshrc
+echo "claude and codex functions cleared. Run: claude --version"

--- a/state/todo.md
+++ b/state/todo.md
@@ -31,11 +31,11 @@
 
 ## Optimization Sprint
 
-- [ ] [shared] Plan the local-runtime hardening pass around project-only checkpoints, common-plan-first coordination, and faster takeover on stalls.
-- [ ] [local] Fix checkpoint scope so only the target project is checkpointed and the runtime repo never self-checkpoints.
-- [ ] [local] Tighten the lead/common-plan/skill-routing prompt contract so local agents coordinate like a Codex-style CLI session.
-- [ ] [local] Reduce idle waiting: stop stalling on resource pressure, downgrade or hand off sooner, and record the runtime lesson.
-- [ ] [shared] Validate the updated live status view so it shows current focus, local-vs-cloud split, and product/business progress from `state/todo.md`.
+- [x] [shared] Plan the local-runtime hardening pass around project-only checkpoints, common-plan-first coordination, and faster takeover on stalls.
+- [x] [local] Fix checkpoint scope so only the target project is checkpointed and the runtime repo never self-checkpoints.
+- [x] [local] Tighten the lead/common-plan/skill-routing prompt contract so local agents coordinate like a Codex-style CLI session.
+- [x] [local] Reduce idle waiting: stop stalling on resource pressure, downgrade or hand off sooner, and record the runtime lesson.
+- [x] [shared] Validate the updated live status view so it shows current focus, local-vs-cloud split, and product/business progress from `state/todo.md`.
 - [ ] [cloud] Run the same action through local-codex and local-claude, capture feedback, and iterate before marking the sprint done.
 
 ## GitHub Governance Sprint
@@ -62,6 +62,14 @@ See `state/plan-claude-codex-sessions.md` for full plan.
 - [x] **User test:** Run `claude` and `codex` in separate terminals, same action in both, use `/feedback <text>`
 - [x] Iterate from `state/feedback-sessions.md` until approved
 - See `state/plan-claude-codex-sessions.md` for full plan.
+
+## Claude = Real CLI (not local agent) — Priority
+
+- [ ] **Plan**: `claude` must open the real Claude CLI by default; local agent only via `./local-claude` or `Local`.
+- [ ] **Fix**: Run `bash scripts/fix_shell_claude_codex.sh --fix`, then `unset -f codex claude 2>/dev/null; source ~/.zshrc` (or open new terminal).
+- [ ] **Verify**: `claude --version` shows real CLI (e.g. 2.1.77); `claude` starts Claude Code, not "Claude (local)".
+- [ ] **Docs**: Update SESSION_COMMANDS.md — claude=real CLI by default; use `./local-claude` for local agent.
+- [ ] **Teach**: Add skill so local agents know: when user asks for "claude", help open real Claude CLI, not local runtime.
 
 ## Current Focus
 


### PR DESCRIPTION
## Summary
- `claude` should start the **real Claude CLI** (Anthropic) by default, not the local agent
- Local agent: use `./local-claude`, `./local-codex`, or `./Local` when explicitly wanted

## Changes
- **fix_shell_claude_codex.sh**: Restores real Claude CLI when overridden; handles local_agent_repo + local-agent-runtime; skips binary files in diagnose (fixes sed illegal byte sequence)
- **use_real_claude.sh**: One-liner to clear cached claude/codex shell functions (`source scripts/use_real_claude.sh`)
- **claude_cli_reinstall.sh**: Uninstall + reinstall Claude CLI for clean independent session
- **docs/SESSION_COMMANDS.md**: Default behavior section - claude=real CLI
- **state/todo.md**: Claude=Real CLI priority section

## How to use real Claude CLI
```bash
# If claude opens local agent (shell function cached):
unset -f codex claude 2>/dev/null; source ~/.zshrc

# Or: source scripts/use_real_claude.sh
```